### PR TITLE
adjust ampacity calculation for matrix conversion, remove uuid

### DIFF
--- a/src/gdm/distribution/components/geometry_branch.py
+++ b/src/gdm/distribution/components/geometry_branch.py
@@ -70,7 +70,11 @@ class GeometryBranch(DistributionBranchBase):
             for detailed electrical analysis.
 
         """
-        equipment = self.equipment.to_matrix_representation(frequency_hz, soil_resistivity_ohm_m, n_neutrals=len([phs for phs in self.phases if phs == Phase.N]))
+        equipment = self.equipment.to_matrix_representation(
+            frequency_hz,
+            soil_resistivity_ohm_m,
+            n_neutrals=len([phs for phs in self.phases if phs == Phase.N]),
+        )
         if isinstance(self.equipment.conductors[0], ConcentricCableEquipment):
             phases = self.phases + [Phase.N for _ in self.phases]
             equipment.kron_reduce(phases)

--- a/src/gdm/distribution/equipment/geometry_branch_equipment.py
+++ b/src/gdm/distribution/equipment/geometry_branch_equipment.py
@@ -13,7 +13,7 @@ from gdm.distribution.equipment.matrix_impedance_branch_equipment import (
 from gdm.quantities import Distance, ResistancePULength, ReactancePULength, CapacitancePULength
 from gdm.distribution.equipment.concentric_cable_equipment import ConcentricCableEquipment
 from gdm.distribution.equipment.bare_conductor_equipment import BareConductorEquipment
-from gdm.distribution.enums import LineType, WireInsulationType, Phase
+from gdm.distribution.enums import LineType, WireInsulationType
 from gdm.constants import PINT_SCHEMA
 
 
@@ -82,7 +82,13 @@ class GeometryBranchEquipment(Component):
         )
         gmrs = [g.conductor_gmr.to("foot").magnitude for g in self.conductors]
         resistance = [g.ac_resistance.to("ohm/mile").magnitude for g in self.conductors]
-        ampacity =  sum([g.ampacity for i, g in enumerate(self.conductors) if i < len(self.conductors) - n_neutrals]) / (len(self.conductors) - n_neutrals)
+        ampacity = sum(
+            [
+                g.ampacity
+                for i, g in enumerate(self.conductors)
+                if i < len(self.conductors) - n_neutrals
+            ]
+        ) / (len(self.conductors) - n_neutrals)
         radii = [g.conductor_diameter.to("feet").magnitude / 2 for g in self.conductors]
         return coordinates, gmrs, resistance, ampacity, radii
 

--- a/tests/test_distribution_system.py
+++ b/tests/test_distribution_system.py
@@ -1,5 +1,6 @@
 from gdm.distribution import DistributionSystem
 from gdm.distribution.components import GeometryBranch, MatrixImpedanceBranch
+from gdm.distribution.equipment import GeometryBranchEquipment
 
 
 def test_distribution_system_with_timeseries(distribution_system_with_single_timeseries):
@@ -21,6 +22,8 @@ def test_geometry_conversion(distribution_system_with_single_timeseries):
     sys.add_component(new_branch)
     assert len(list(sys.get_components(MatrixImpedanceBranch))) == 17
     assert len(list(sys.get_components(GeometryBranch))) == 1
+    assert len(list(sys.get_components(GeometryBranchEquipment))) == 1
     sys.convert_geometry_to_matrix_representation()
     assert len(list(sys.get_components(MatrixImpedanceBranch))) == 18
     assert len(list(sys.get_components(GeometryBranch))) == 0
+    assert len(list(sys.get_components(GeometryBranchEquipment))) == 0

--- a/tests/test_impedence_calc.py
+++ b/tests/test_impedence_calc.py
@@ -62,9 +62,9 @@ def test_kron_reduction_overhead_three_phase_with_neutral():
         horizontal_positions=Distance([-4, -1.5, 3, 0], "feet"),
         vertical_positions=Distance([29, 29, 29, 25], "feet"),
     )
-    branches = equip.to_matrix_representation()
+    branches = equip.to_matrix_representation(n_neutrals=1)
     assert branches.r_matrix.shape == (4, 4)
-
+    assert branches.ampacity == Current(300, "ampere")
     branches.kron_reduce(phases=[Phase.A, Phase.B, Phase.C, Phase.N])
 
     r_from_kerstings = np.array(


### PR DESCRIPTION

- Ampacity calculation on conversion from geometry to matrix branch representation averaged per-phase ampacity across all phases including neutrals. Neutrals have now been excluded from this calculation.
- Consistent use of UUIDs for equipment caused unintended preservation of equipment pointers and issues with the resulting gdm. While simple, this solution implementation does have the downside of individual equipment where there may have previously been just one. 



<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes.
* [ ] Tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including "please review" to assign reviewers**