### PR TITLE
tap position clarification and winding validation

### DIFF
--- a/src/gdm/distribution/components/base/distribution_transformer_base.py
+++ b/src/gdm/distribution/components/base/distribution_transformer_base.py
@@ -86,7 +86,7 @@ class DistributionTransformerBase(InServiceDistributionComponentBase, ABC):
                     f" which is allowed only for delta connected configuration i.e. phase length =2."
                 )
                 raise ValueError(msg)
-            elif pw_phases_length == 2 and wdg.num_phases != 1:
+            elif pw_phases_length == 2 and wdg.num_phases != 1 and "DELTA" in wdg.connection_type:
                 msg = (
                     f"For a single phase delta connected transformer, {pw_phases=}"
                     f" inconsistant number of phases provided for winding {wdg.num_phases=}"

--- a/src/gdm/distribution/equipment/distribution_transformer_equipment.py
+++ b/src/gdm/distribution/equipment/distribution_transformer_equipment.py
@@ -56,7 +56,7 @@ class WindingEquipment(Component):
         list[float],
         Field(
             ...,
-            description="List of per unit tap positions for each phase. Centered at 0.",
+            description="List of per unit tap positions for each phase. Centered at 1.0.",
         ),
     ]
     total_taps: Annotated[
@@ -82,11 +82,11 @@ class WindingEquipment(Component):
             )
             raise ValueError(msg)
         for tap in self.tap_positions:
-            if not abs(tap) <= self.total_taps / 2:
+            if not (self.min_tap_pu <= tap <= self.max_tap_pu):
                 msg = (
                     f"Tap position {tap=} outside allowable range"
-                    f" of [{-1*self.total_taps/2=}-{self.total_taps/2=}] for"
-                    f" total taps of {self.total_taps=}."
+                    f" of [{self.min_tap_pu=}-{self.max_tap_pu=}] for"
+                    f" this winding."
                 )
                 raise ValueError(msg)
 


### PR DESCRIPTION

## Change Summary

Change tap position doc string to be "centered at 1.0."
Change tap position to align with per unit value.
Change a winding validation to just hit delta config as written. (Has an issue where 2 phase wye was tripping this. 

## Related issue number

https://github.com/NREL-Distribution-Suites/grid-data-models/issues/129

## Checklist

* [ ] The pull request title is a good summary of the changes.
* [ ] Tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including "please review" to assign reviewers**