### PR TITLE
reg controller winding field

### DIFF
--- a/src/gdm/distribution/controllers/distribution_regulator_controller.py
+++ b/src/gdm/distribution/controllers/distribution_regulator_controller.py
@@ -20,6 +20,17 @@ class RegulatorController(Component):
     """Data model for a Regulator Controller."""
 
     name: Annotated[str, Field("", description="Name of the regulator controller.")]
+
+    tapped_winding: Annotated[
+        Optional[int],
+        Field(
+            2,
+            ge=1,
+            le=3,
+            description="The index of the winding on the transformer that this controller is controlling.",
+        ),
+    ]
+
     delay: Annotated[
         Optional[Time],
         PINT_SCHEMA,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->

## Change Summary

Add a field to Regulator controllers to specify which winding is to be acted upon. If not specified, when converted to opendss, a default of 1 will take effect, which is often wrong.

## Related issue number

<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] The pull request title is a good summary of the changes.
* [ ] Tests for the changes exist
* [ ] Tests pass on CI
* [ ] Documentation reflects the changes where applicable
* [ ] My PR is ready to review, **please add a comment including "please review" to assign reviewers**